### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides tools for managing Google Cloud Dataproc clusters and jobs. This server enables AI assistants to interact with Dataproc resources through a standardized interface.
 
+<a href="https://glama.ai/mcp/servers/@warrenzhu25/dataproc-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@warrenzhu25/dataproc-mcp/badge" alt="Dataproc Server MCP server" />
+</a>
+
 ## Features
 
 ### Cluster Management


### PR DESCRIPTION
This PR adds a badge for the [Dataproc MCP Server](https://glama.ai/mcp/servers/@warrenzhu25/dataproc-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@warrenzhu25/dataproc-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@warrenzhu25/dataproc-mcp/badge" alt="Dataproc Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.